### PR TITLE
Added Fan Device Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/nora-common"]
 	path = src/nora-common
-	url = https://github.com/andrei-tatar/nora-common.git
+	url = https://github.com/CapnScabby/nora-common.git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+#First Time Setup
+Initialize git submodule:
+`git submodule init`
+`git submodule update`
+
+Setup npm depednencies:
+`npm install`
+
+Install typescript
+Ubuntu: `sudo apt install node-typescript`
+
+Compile the code, run in the repo root:
+`tsc`
 
 # nora-service
 NORA (https://node-red-google-home.herokuapp.com) backend service deployed in Heroku.
@@ -12,8 +25,9 @@ Needed:
 
 ## HEROKU
 
-- Create a new Account and then a new app. From Overview, add new add-on "Heroku Postgres"
-To deploy, you can either use the heroku cli or connect your github account. (do not deploy anything yet)
+- Create a new Account and then a new app.
+ - From Overview, add new add-on "Heroku Postgres"
+To deploy, you need to use the heroku cli. (do not deploy anything yet)
  - Keep this browser tab open
 
 ## FIREBASE
@@ -21,7 +35,8 @@ To deploy, you can either use the heroku cli or connect your github account. (do
  - Create a new Firebase Project and name it accordingly.
  - Navigate to Project Overview - Project Settings - General and create a new web app.
  - Navigate to Project Overview - Project Settings - Service Accounts and generate new private key
- - Navigate to Develop - Authentication - Users - Set up sign-in method - Google - enable - check that Web SDK configuration is filled in.
+ - Navigate to Sidebar - Authentication - Sign-in method - Google - enable - check that Web SDK configuration is filled in.
+ - Navigate to Sidebar - Authentication - Authorized domains - add heroku app to the list, e.g. https://XXXXXXXXX.herokuapp.com
  - Keep this browser tab open
 
 ## Google Api Console
@@ -62,6 +77,9 @@ In Heroku go to Settings - Config Vars and add
     SERVICE_ACCOUNT_KEY =  downloaded service account json from firebase - private_key (format it as multiline)
     FIREBASE_APIKEY = firebase - settings -general - your apps
     FIREBASE_AUTHDOMAIN = firebase - settings -general - your apps
+    PROJECT_API_KEY = google api console - credentials - create API key
+    
+    NOTE!: When you add the Postgres Database, heroku should add a DATABASE_URL env var automatically!
 
 ## USER.REPOSITORY.TS
 Modify [src/services/user.repository.ts](https://github.com/andrei-tatar/nora-service/blob/master/src/services/user.repository.ts)
@@ -74,7 +92,7 @@ To create the Database Tables modify this lines:
             CREATE TABLE IF NOT EXISTS appuser (
                 uid VARCHAR(30) CONSTRAINT pk PRIMARY KEY,
                 linked boolean DEFAULT false
-            )`
+noradevtest            )`
         );
     
         await service.query('ALTER TABLE appuser ADD COLUMN IF NOT EXISTS noderedversion integer DEFAULT 1');
@@ -88,10 +106,26 @@ To create the Database Tables modify this lines:
 
 ## PUSH
 
-THAT'S IT, you are ready to deploy to Heroku! 
-Build the app and the  schema with `npm run heroku-postbuild` before deploying.
-To deploy follow the instructions from the Heroku website or if you linked your account in Heroku with Github just push to github.
+THAT'S IT, you are ready to deploy to Heroku!
 
+To deploy, you must the heroku cli. 
+
+Deploying through git won't work, because of the git submodule.
+
+Install the heroku cli: https://devcenter.heroku.com/articles/heroku-cli#download-and-install
+
+Enable the heroku cli by going through Heroku dashboard, deployment tab, and clicking heroku git.
+
+Build the app and the  schema with `npm run heroku-postbuild` before deploying.
+
+Add the heroku git remote:
+`heroku git:remote -a HEROKU_APP_NAME`
+
+Then use git to push the repo to heroku:
+`git push heroku`
+
+To view application output, run:
+`heroku logs`
 ## README DISCLAIMER
 
 The instructions might be incomplete. For issues with the instructions please create an issue and we'll take another look,

--- a/schema/sync.json
+++ b/schema/sync.json
@@ -119,6 +119,6690 @@
             {
                 "additionalProperties": false,
                 "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "ack"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pin": {
+                        "type": "string"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "pin"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "pin",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedPercent": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedPercent",
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            true
+                        ],
+                        "type": "boolean"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedPercent": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedPercent",
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            true
+                        ],
+                        "type": "boolean"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "ack"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "availableFanSpeeds": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "ordered": {
+                                "enum": [
+                                    true
+                                ],
+                                "type": "boolean"
+                            },
+                            "speeds": {
+                                "additionalItems": {
+                                    "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S1"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "low"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 1"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S2"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "medium"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 2"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S3"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 3"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "speed_name": {
+                                                    "enum": [
+                                                        "S4"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "speed_values": {
+                                                    "additionalItems": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "lang": {
+                                                                        "enum": [
+                                                                            "en"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    "speed_synonym": {
+                                                                        "additionalItems": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "max"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                {
+                                                                                    "enum": [
+                                                                                        "speed 4"
+                                                                                    ],
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "items": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "minItems": 2,
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "lang",
+                                                                    "speed_synonym"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "items": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ],
+                                                    "minItems": 1,
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "speed_name",
+                                                "speed_values"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "items": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S1"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "low"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 1"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "low"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 1"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "low"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 1"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S2"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "medium"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 2"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "medium"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 2"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "medium"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 2"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S3"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "high"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 3"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "high"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 3"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "high"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 3"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "speed_name": {
+                                                "enum": [
+                                                    "S4"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "speed_values": {
+                                                "additionalItems": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "lang": {
+                                                                    "enum": [
+                                                                        "en"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "speed_synonym": {
+                                                                    "additionalItems": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "enum": [
+                                                                                    "max"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "enum": [
+                                                                                    "speed 4"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "items": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "lang",
+                                                                "speed_synonym"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "items": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "lang": {
+                                                                "enum": [
+                                                                    "en"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "speed_synonym": {
+                                                                "additionalItems": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "enum": [
+                                                                                "max"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "enum": [
+                                                                                "speed 4"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "items": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "max"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "speed 4"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "minItems": 2,
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "lang",
+                                                            "speed_synonym"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "minItems": 1,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "speed_name",
+                                            "speed_values"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ],
+                                "minItems": 4,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "ordered",
+                            "speeds"
+                        ],
+                        "type": "object"
+                    },
+                    "commandOnlyFanSpeed": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pin": {
+                        "type": "string"
+                    },
+                    "reversible": {
+                        "enum": [
+                            false
+                        ],
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "currentFanSpeedPercent": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "currentFanSpeedSetting": {
+                                "$ref": "#/definitions/FanSpeedMode"
+                            },
+                            "on": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "currentFanSpeedPercent",
+                            "currentFanSpeedSetting",
+                            "on",
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "supportsFanSpeedPercent": {
+                        "enum": [
+                            true
+                        ],
+                        "type": "boolean"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "pin"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "fan"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "availableFanSpeeds",
+                    "commandOnlyFanSpeed",
+                    "name",
+                    "pin",
+                    "reversible",
+                    "state",
+                    "supportsFanSpeedPercent",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
                     "name": {
                         "type": "string"
                     },
@@ -432,6 +7116,9 @@
                         ],
                         "type": "object"
                     },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
+                    },
                     "type": {
                         "enum": [
                             "light"
@@ -495,6 +7182,9 @@
                             "online"
                         ],
                         "type": "object"
+                    },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
                     },
                     "twoFactor": {
                         "enum": [
@@ -569,6 +7259,9 @@
                             "online"
                         ],
                         "type": "object"
+                    },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
                     },
                     "twoFactor": {
                         "enum": [
@@ -677,6 +7370,9 @@
                             "online"
                         ],
                         "type": "object"
+                    },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
                     },
                     "type": {
                         "enum": [
@@ -779,6 +7475,9 @@
                         ],
                         "type": "object"
                     },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
+                    },
                     "twoFactor": {
                         "enum": [
                             "ack"
@@ -889,6 +7588,9 @@
                             "online"
                         ],
                         "type": "object"
+                    },
+                    "turnOnWhenBrightnessChanges": {
+                        "type": "boolean"
                     },
                     "twoFactor": {
                         "enum": [
@@ -2301,6 +9003,183 @@
                     "queryOnlyTemperatureSetting",
                     "state",
                     "temperatureUnit",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pausable": {
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "isDocked": {
+                                "type": "boolean"
+                            },
+                            "isPaused": {
+                                "type": "boolean"
+                            },
+                            "isRunning": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "type": {
+                        "enum": [
+                            "vacuum"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "state",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pausable": {
+                        "type": "boolean"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "isDocked": {
+                                "type": "boolean"
+                            },
+                            "isPaused": {
+                                "type": "boolean"
+                            },
+                            "isRunning": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "ack"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "vacuum"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "state",
+                    "twoFactor",
+                    "type"
+                ],
+                "type": "object"
+            },
+            {
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "nicknames": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pausable": {
+                        "type": "boolean"
+                    },
+                    "pin": {
+                        "type": "string"
+                    },
+                    "roomHint": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "isDocked": {
+                                "type": "boolean"
+                            },
+                            "isPaused": {
+                                "type": "boolean"
+                            },
+                            "isRunning": {
+                                "type": "boolean"
+                            },
+                            "online": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "online"
+                        ],
+                        "type": "object"
+                    },
+                    "twoFactor": {
+                        "enum": [
+                            "pin"
+                        ],
+                        "type": "string"
+                    },
+                    "type": {
+                        "enum": [
+                            "vacuum"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "pin",
+                    "state",
                     "twoFactor",
                     "type"
                 ],
@@ -2309,6 +9188,15 @@
         ]
     },
     "definitions": {
+        "FanSpeedMode": {
+            "enum": [
+                "S1",
+                "S2",
+                "S3",
+                "S4"
+            ],
+            "type": "string"
+        },
         "LockUnlockState": {
             "additionalProperties": false,
             "properties": {

--- a/schema/update.json
+++ b/schema/update.json
@@ -18,6 +18,12 @@
                 "$ref": "#/definitions/Partial<Thermostat>"
             },
             {
+                "$ref": "#/definitions/Partial<OnOffState&FanSpeedModeState>"
+            },
+            {
+                "$ref": "#/definitions/Partial<OnOffState&FanSpeedModeState&FanSpeedPercentState>"
+            },
+            {
                 "$ref": "#/definitions/Partial<BrightnessState&OnOffState>"
             },
             {
@@ -28,6 +34,9 @@
             },
             {
                 "$ref": "#/definitions/Partial<Partial<Thermostat>>"
+            },
+            {
+                "$ref": "#/definitions/Partial<StartStopState&DockState>"
             }
         ]
     },
@@ -116,6 +125,53 @@
             },
             "type": "object"
         },
+        "Partial<OnOffState&FanSpeedModeState&FanSpeedPercentState>": {
+            "additionalProperties": false,
+            "properties": {
+                "currentFanSpeedPercent": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "currentFanSpeedSetting": {
+                    "enum": [
+                        "S1",
+                        "S2",
+                        "S3",
+                        "S4"
+                    ],
+                    "type": "string"
+                },
+                "on": {
+                    "type": "boolean"
+                },
+                "online": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<OnOffState&FanSpeedModeState>": {
+            "additionalProperties": false,
+            "properties": {
+                "currentFanSpeedSetting": {
+                    "enum": [
+                        "S1",
+                        "S2",
+                        "S3",
+                        "S4"
+                    ],
+                    "type": "string"
+                },
+                "on": {
+                    "type": "boolean"
+                },
+                "online": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "Partial<OnOffState>": {
             "additionalProperties": false,
             "properties": {
@@ -179,6 +235,24 @@
                 },
                 "thermostatTemperatureSetpointLow": {
                     "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<StartStopState&DockState>": {
+            "additionalProperties": false,
+            "properties": {
+                "isDocked": {
+                    "type": "boolean"
+                },
+                "isPaused": {
+                    "type": "boolean"
+                },
+                "isRunning": {
+                    "type": "boolean"
+                },
+                "online": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,7 +92,7 @@ if (isLocal && typeof local.postgresSsl === 'boolean') {
     }
 }
 export const postgres = {
-    connectionString: 'postgres://ohubflebemtayr:798e58067843da246bd9e3016c16b1e91e8429ed1f835bc028b4654905476c4b@ec2-79-125-26-232.eu-west-1.compute.amazonaws.com:5432/d971p7nrn8fnsv',
+    connectionString: getCfg('DATABASE_URL'),
     ssl: ssl,
     max: (isLocal ? local.postgresMax : ~~getCfg('POSTGRES_MAX')) || 5,
     idleTimeoutMillis: (isLocal ? local.postgresIdleTimeoutMills : ~~getCfg('POSTGRES_IDLETIMEOUTMILLS')) || 4 * this.HOUR,

--- a/src/google/sync.ts
+++ b/src/google/sync.ts
@@ -46,6 +46,8 @@ export enum Traits {
     TemperatureSetting = 'action.devices.traits.TemperatureSetting',
     Volume = 'action.devices.traits.Volume',
     OpenClose = 'action.devices.traits.OpenClose',
+    FanSpeed = 'action.devices.traits.FanSpeed',
+    FanSpeedPercent = 'action.devices.traits.FanSpeedPercent',
 }
 
 export enum DeviceTypes {
@@ -58,4 +60,5 @@ export enum DeviceTypes {
     Blinds = 'action.devices.types.BLINDS',
     Garage = 'action.devices.types.GARAGE',
     Lock = 'action.devices.types.LOCK',
+    Fan = 'action.devices.types.FAN',
 }

--- a/src/http/services/query.service.ts
+++ b/src/http/services/query.service.ts
@@ -71,6 +71,13 @@ export class QueryService {
                 state.isLocked = device.state.isLocked;
                 state.isJammed = device.state.isJammed;
                 break;
+            case 'fan':
+                state.on = device.state.on;
+                state.currentFanSpeedSetting = device.state.currentFanSpeedSetting;
+                if (device.supportsFanSpeedPercent) {
+                    state.currentFanSpeedPercent = device.state.currentFanSpeedPercent || 100;
+                }
+                break;
         }
     }
 }

--- a/src/http/services/sync.service.ts
+++ b/src/http/services/sync.service.ts
@@ -109,6 +109,16 @@ export class SyncService {
                         sync.type = DeviceTypes.Lock;
                         sync.traits.push(Traits.LockUnlock);
                         break;
+                    case 'fan':
+                        sync.type = DeviceTypes.Fan;
+                        sync.traits.push(Traits.OnOff, Traits.FanSpeed);
+                        sync.attributes = {
+                            availableFanSpeeds: device.availableFanSpeeds,
+                            reversible: device.reversible,
+                            supportsFanSpeedPercent: device.supportsFanSpeedPercent,
+                            commandOnlyFanSpeed: device.commandOnlyFanSpeed,
+                        };
+                        break;
                 }
                 syncDevices.push(sync);
             }

--- a/test/fan_integration_test.js
+++ b/test/fan_integration_test.js
@@ -1,0 +1,139 @@
+#!/usr/bin/node
+const TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJVazVIZVBjUGtEUzVZUmtNZHdsTlRjeW1LNzMzIiwic2NvcGUiOiJub2RlLXJlZCIsInZlcnNpb24iOjEsImlhdCI6MTU5NDk3NjA4NX0.0-PUuGO9PnE1bzaWmQU8mL2jwZo4loW9fvrswaUZtGI"
+const URI = 'https://noradevtest.herokuapp.com/?version='+'0.0.30'+'&token=' + encodeURIComponent(TOKEN) + "&notify=" + true;
+const util = require('util');
+
+function inspect(object) {
+    console.log(util.inspect(object, {showHidden: false, depth: null}))
+}
+
+var fan_speeds = {
+    'speeds': [
+    {
+        'speed_name': 'S1',
+        'speed_values': [{
+            'speed_synonym': ['low', 'speed 1'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S2',
+        'speed_values': [{
+            'speed_synonym': ['medium', 'speed 2'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S3',
+        'speed_values': [{
+            'speed_synonym': ['high', 'speed 3'],
+            'lang': 'en'
+        }]
+    },
+    {
+        'speed_name': 'S4',
+        'speed_values': [{
+            'speed_synonym': ['max', 'speed 4'],
+            'lang': 'en'
+        }]
+    }
+    ],
+    'ordered': true
+}
+
+var devices = {
+    'Primary Fan' : {
+        'type': 'fan',
+        'name': 'Primary Fan',
+        'roomHint': 'living room',
+        'reversible': false,
+        'supportsFanSpeedPercent': false,
+        'commandOnlyFanSpeed': false,
+        'availableFanSpeeds': fan_speeds,
+        'state': {
+            'on': true,
+            'currentFanSpeedSetting': 'S1',
+            'online': true,
+        }
+    },
+    'Secondary Fan' : {
+        'type': 'fan',
+        'name': 'Secondary Fan',
+        'roomHint': 'living room',
+        'reversible': false,
+        'supportsFanSpeedPercent': true,
+        'commandOnlyFanSpeed': false,
+        'availableFanSpeeds': fan_speeds,
+        'state': {
+            'on': true,
+            'currentFanSpeedSetting': 'S1',
+            'online': true,
+            'currentFanSpeedPercent': 10
+        }
+    }
+}
+            
+
+var socket_io_client = require('socket.io-client')(URI);
+//From Nora API
+socket_io_client.on('connect', function(){
+        console.log("Connected")
+        inspect(devices);
+        socket_io_client.emit('sync', devices, 'req:sync');
+        socket_io_client.emit('resync', devices, 'req:resync');
+});
+//From Nora API
+socket_io_client.on('update', function (msg){
+    console.log("got an update")
+    last_nora_update = new Date();
+    inspect(msg);
+    Object.keys(msg).forEach(function (device) {
+        var update = {};
+        update[device] = msg[device];
+        Object.keys(msg[device]).forEach(function (trait) {
+            inspect(trait);
+            inspect(msg[device][trait]);
+            if (devices[device]['state'].hasOwnProperty(trait)) {
+                console.log(`device has trait ${trait}`);
+                devices[device]['state'][trait]=msg[device][trait];
+            } else {
+                if (trait === 'fanSpeedPercent') {
+                    devices[device]['state']['currentFanSpeedPercent'] = msg[device][trait];
+                    if (msg[device].hasOwnProperty('currentFanSpeedPercent')) {
+                        msg[device]['currentFanSpeedPercent'] = msg[device][trait];
+                    }
+                } else if (trait === 'fanSpeed') {
+                    devices[device]['state']['currentFanSpeedSetting'] = msg[device][trait];
+                    if (msg[device].hasOwnProperty('currentFanSpeedSetting')) {
+                        msg[device]['currentFanSpeedSetting'] = msg[device][trait];
+                    }
+                }
+            }
+        });
+        inspect(devices[device]['state']);
+        socket_io_client.emit('update', {'device': devices[device]['state']}, "req:" + device );
+    });
+});
+socket_io_client.on('action-error', function (reqId, msg) {
+    if (reqId === 'req:sync') {
+        console.log("nora: sync error (" + msg + ")");
+    }
+    console.log('action-error message: ');
+    inspect(reqId);
+    inspect(msg);
+});
+socket_io_client.on('activate-scene', function (ids, deactivate) { 
+    console.log('activate-scene message: ')
+    console.inspect(ids);
+    console.inspect(deactivate);
+});
+socket_io_client.on('error', function(err) {
+    console.log("Detected error:");
+    inspect(err);
+});
+//From Nora API
+socket_io_client.on('disconnect', function(reason){
+    console.log("Disconnected from nora because of " + reason)
+});
+
+socket_io_client.connect()


### PR DESCRIPTION
As Per issue 7: https://github.com/andrei-tatar/node-red-contrib-nora/issues/7

We are adding fan support. 

This adds support for fans with 4 speed modes, and percentage based fan speeds.

It does not support fans that are reversible. 

It includes a node js test service that can be used to verify that fans are working. 

I created a full test environment and verified that all google fan control commands were working as intended. 

Depends on: https://github.com/andrei-tatar/nora-common/pull/2